### PR TITLE
Add requirements and postBuild to enable binder demo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,15 @@ Installation
     jupyter nbextension     enable --py appmode
     jupyter serverextension enable --py appmode
 
+
+Try it live
+-----------
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/oschuett/appmode/master?filepath=%2Fapps%2Fexample_app.ipynb)
+
+Click the binder badge to try it live without installing anything. This will take you directly to the "app" version of the notebook.
+
+
 Description
 -----------
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+jupyter nbextension     enable --py appmode
+jupyter serverextension enable --py appmode
+
+# Notebooks w/ extensions that auto-run code must be "trusted" to work the first time
+jupyter trust example_app.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+appmode


### PR DESCRIPTION
This extension is pretty awesome!

Try out the PR here: https://mybinder.org/v2/gh/betatim/appmode/bindering?urlpath=%2Fapps%2Fexample_app.ipynb

These changes let you run this repo on binder and take you directly to the app mode. I mean: "Hello shiny apps!!"

One thing I am not too happy with: I had to add `appmode` to the `requirements.txt` ... which most python people would consider pretty circular. Is it better to add a `pip install appmode` to the `postBuild`? Maybe @choldgraf or @yuvipanda have opinions?