### PR TITLE
Fix jupyter-js-widgets race condition

### DIFF
--- a/appmode/static/main.js
+++ b/appmode/static/main.js
@@ -140,10 +140,6 @@ define([
             this.CodeMirror.setOption('readOnly', "nocursor");
         });
 
-        // run all cells
-        Jupyter.notebook.clear_all_output();
-        Jupyter.notebook.execute_all_cells();
-
         // register kernel events
         events.on('kernel_idle.Kernel',  kernel_idle_handler);
         events.on('kernel_busy.Kernel',  kernel_busy_handler);
@@ -151,11 +147,25 @@ define([
         // register on_click handler
         $('#appmode-leave').click(goto_normal_mode);
 
+        // clear all cell outputs persisted in the initial notebook
+        Jupyter.notebook.clear_all_output();
+        // try to load the jupyter-js-widgets extension to see if it's installed
+        utils.load_extension('jupyter-js-widgets/extension').then(function(module) {
+            // force the extension to initialize if it exists, even if it's a repeat
+            // operation, to avoid a race condition with executing cells that contain
+            // widgets
+            module.load_ipython_extension().then(initialize_step5);
+        }).catch(initialize_step5);
+    }
+
+    //==========================================================================
+    function initialize_step5() {
         // hide loading screen
         $('#appmode-loader').slideUp();
-
+        // execute all cells
+        Jupyter.notebook.execute_all_cells();
         console.log("Appmode: initialization finished");
-    }
+    };
 
     //==========================================================================
     var load_ipython_extension = function() {


### PR DESCRIPTION
When loading an appmode page using ipywidgets, there appears to be a race condition between the appmode executing all cells and jupyter-js-widgets being truly ready for use. The bug is hard to reproduce locally, but shows up frequently for certain notebooks loaded over a network:

![appmode-race](https://user-images.githubusercontent.com/153745/51432816-12140d00-1c0c-11e9-88cc-8cebbba3470b.gif)

This PR uses `utils.load_extension` to get a promise which resolves when jupyter-js-widgets is installed and loaded. It then forces initialization of the widgets extension to get another promise which resolves when the widgets are ready for use. Appmode completes initialization and executes all cells when the first promise raises (i.e., jupyter-js-widgets is not installed) or the second promise resolves (i.e., widgets are fully initialized). The same notebook shown above behaves properly after this code change:

![appmode-race-fix](https://user-images.githubusercontent.com/153745/51432867-ee9d9200-1c0c-11e9-9b22-342c155c95be.gif)

I toyed around some but could not find a more elegant fix for the problem.