### PR TITLE
Server side options for trusted path, hiding buttons

### DIFF
--- a/appmode/appmode.html
+++ b/appmode/appmode.html
@@ -9,15 +9,19 @@
     <img src="{{ base_url + "nbextensions/appmode/gears.svg" }}" title="App is loading...">
   </div>
 
+  {% if show_edit_button %}
   <span>
      <button id="appmode-leave" class="btn btn-default btn-sm navbar-btn pull-right" title="Edit this app as notebook">Edit App</button>
   </span>
+  {% endif %}
+
   <span>
      <img id="appmode-busy" src="{{ base_url + "nbextensions/appmode/gears.svg" }}" title="Kernel Busy">
   </span>
 
-
+  {% if show_other_buttons %}
   {{super()}}
+  {% endif %}
 
 {% endblock header_buttons %}
 

--- a/appmode/appmode_bottom.css
+++ b/appmode/appmode_bottom.css
@@ -34,3 +34,7 @@
 #menubar-container {
     display: none !important;
 }
+
+#ipython_notebook {
+    flex-grow: 1 !important;
+}

--- a/appmode/server_extension.py
+++ b/appmode/server_extension.py
@@ -7,7 +7,7 @@ from notebook.base.handlers import IPythonHandler, FilesRedirectHandler, path_re
 import notebook.notebook.handlers as orig_handler
 from tornado import web
 from traitlets.config import LoggingConfigurable
-from traitlets import Unicode
+from traitlets import Bool, Unicode
 
 
 class AppmodeManager(LoggingConfigurable):
@@ -16,14 +16,25 @@ class AppmodeManager(LoggingConfigurable):
     Defined separately from the AppmodeHandler to avoid multiple inheritance
     and constructor conflicts.
     """
-    trusted_path = Unicode(help="Only allow notebooks under this web path to launch in app mode", config=True)
-
+    trusted_path = Unicode('', help="Only allow notebooks under this web path to launch in app mode", config=True)
+    show_edit_button = Bool(True, help="Show Edit App button in the appmode header", config=True)
+    show_other_buttons = Bool(True, help="Show other notebook buttons in the appmode header (e.g., Logout)", config=True)
 
 class AppmodeHandler(IPythonHandler):
     @property
     def trusted_path(self):
         """Trusted appmode path"""
         return self.settings['appmode_manager'].trusted_path
+
+    @property
+    def show_edit_button(self):
+        """Edit App button in appmode header"""
+        return self.settings['appmode_manager'].show_edit_button
+
+    @property
+    def show_other_buttons(self):
+        """Other buttons in appmode header"""
+        return self.settings['appmode_manager'].show_other_buttons
 
     #===========================================================================
     @web.authenticated
@@ -67,6 +78,8 @@ class AppmodeHandler(IPythonHandler):
             'kill_kernel': False,
             'mathjax_url': self.mathjax_url,
             'mathjax_config': self.mathjax_config,
+            'show_edit_button': self.show_edit_button,
+            'show_other_buttons': self.show_other_buttons,
         }
 
         # template parameters changed over time

--- a/appmode/server_extension.py
+++ b/appmode/server_extension.py
@@ -132,7 +132,7 @@ def load_jupyter_server_extension(nbapp):
     #nbapp.extra_template_paths.append(tmpl_dir) # dows
 
     # For configuration values that can be set server side
-    mgr = AppmodeManager(parent=nbapp)
+    mgr = Appmode(parent=nbapp)
     nbapp.web_app.settings['appmode_manager'] = mgr
 
     # slight violation of Demeter's Law

--- a/appmode/server_extension.py
+++ b/appmode/server_extension.py
@@ -10,8 +10,8 @@ from traitlets.config import LoggingConfigurable
 from traitlets import Bool, Unicode
 
 
-class AppmodeManager(LoggingConfigurable):
-    """Manager object containing server-side configuration settings for appmode.
+class Appmode(LoggingConfigurable):
+    """Object containing server-side configuration settings for appmode.
 
     Defined separately from the AppmodeHandler to avoid multiple inheritance
     and constructor conflicts.


### PR DESCRIPTION
For #22:

* `--Appmode.trusted_path=/some/path` - Only notebooks loaded from this web page (which may be a local directory of the same name under the configured `--notebook-dir` or a virtual path provided by a custom `ContentsManager`) will enter appmode automatically and run all cells. Defaults to `''` to trust all  paths and retain the current behavior.
* `--Appmode.show_edit_button=True` - Show/hide the *Edit App* button when in appmode. Defaults to `True` to retain the current behavior.
* `--Appmode.show_other_button=True` - Show/hide other Jupyter header buttons (e.g., Logout) when in appmode. Defaults to `True` to retain the current behavior.

I'm happy to add a commit to the PR updating the README to document these options once we agree on them.