### PR TITLE
fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Appmode consist of a server-side and a notebook extension for Jupyter. Together 
 Appmode adds the following [configuration options](https://jupyter-notebook.readthedocs.io/en/stable/config.html):
 - `Appmode.trusted_path` Run only notebooks below this path in Appmode. Default: No restrictions.
 - `Appmode.show_edit_button` Show _Edit App_ button during Appmode. Default: True.
-- `Appmode.show_other_button` Show other buttons, e.g. Logout, during Appmode. Default: True.
+- `Appmode.show_other_buttons` Show other buttons, e.g. Logout, during Appmode. Default: True.
 
 ## Client Side Customization
 


### PR DESCRIPTION
Should be c.Appmode.show_other_buttons, not c.Appmode.show_other_button