### PR TITLE
Add DEBIAN_FRONTEND="noninteractive" to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ FROM ubuntu:rolling
 USER root
 
 # Install some Debian package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN export DEBIAN_FRONTEND="noninteractive" \
+  && apt-get update && apt-get install -y --no-install-recommends \
     python3-setuptools     \
     python3-wheel          \
     python3-pip            \


### PR DESCRIPTION
### Summary

For installing via `apt`, the docker file misses setting `DEBIAN_FRONTEND="noninteractive"`, causing the build to stall on my system. Setting the environment variable in the `Dockerfile` fixes the issue.


### Bug Report

Without the change proposed in this PR, the build fails.

#### Steps to repro:

Follow the instructions in the README: Clone repository and call

``` bash
docker build --tag appmode_dev ./
```

within the root directory.

#### Expected Behavior:

Container builds.

#### Actual Behavior:

```
[...]
Setting up tzdata (2020a-0ubuntu0.20.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 
```

#### System info

``` bash
docker --version
Docker version 19.03.8-ce, build afacb8b7f0
```