### PR TITLE
Ensure async handling for `FilesRedirectHandler` calls

### DIFF
--- a/appmode/server_extension.py
+++ b/appmode/server_extension.py
@@ -91,12 +91,12 @@ class AppmodeHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterH
         except web.HTTPError as e:
             if e.status_code == 404 and "files" in path.split("/"):
                 # 404, but '/files/' in URL, let FilesRedirect take care of it
-                return FilesRedirectHandler.redirect_to_files(self, path)
+                return await ensure_async(FilesRedirectHandler.redirect_to_files(self, path))
             else:
                 raise
         if model["type"] != "notebook":
             # not a notebook, redirect to files
-            return FilesRedirectHandler.redirect_to_files(self, path)
+            return await ensure_async(FilesRedirectHandler.redirect_to_files(self, path))
 
         # fix back button navigation
         self.add_header(


### PR DESCRIPTION
Jupyter Server 1.1.1 made this async. Though it worked at least at 1.19, in 2.16, this API inconsistency breaks the redirect. Here we simply address the asynchronous nature of the method by awaiting.

Closes #83 